### PR TITLE
Remove exception catching

### DIFF
--- a/src/test/java/gov/disasterassistance/daip/test/User.java
+++ b/src/test/java/gov/disasterassistance/daip/test/User.java
@@ -62,12 +62,6 @@ public class User {
 	*************************************************************************/	
 	@Step
 	public void shouldSeePage(String expectedPageName) {
-		String pageTitle = "";
-		try {
-			pageTitle = daPage.pullPageTitle();
-		} catch (NoSuchElementException e) {
-			// do nothing
-		}
 
 		switch (expectedPageName) {
 		case "get assistance":
@@ -115,7 +109,9 @@ public class User {
 		case "accesibilidad":
 		case "download plug-ins":
 		case "descargar plug-ins":
-			Assert.assertEquals(expectedPageName.toLowerCase(), pageTitle.toLowerCase());
+			// TODO: Should this assertion be done on all pages?
+			// If so, delete all cases above this and move this assertion to after switch
+			Assert.assertEquals(expectedPageName.toLowerCase(), daPage.pullPageTitle().toLowerCase());
 			break;
 		
 		case "home":


### PR DESCRIPTION
Test fails if page title isn’t found, and move page title load to only be done when needed.

After looking at this for a second longer, the assertion would fail this anyway when pageTitle was empty string. Whatevs, this is less lines of code  and the comment might be useful, otherwise this PR can be scrapped.